### PR TITLE
Python3, TTI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Generic files to ignore
+*~
+*.lock
+*.DS_Store
+*.swp
+*.out
+*.kate-swp
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ Have fun :wink:
 
 Using digital PIN 2 for the green led and digital pin 6 for the red led
 
-![Image not available for now, please contact support on discord](https://github.com/NaomiProject/controlLED/blob/master/wiring)
+![Image not available for now, please contact support on discord](https://github.com/NaomiProject/controlLED/blob/master/SerialTest.png)
 
 **Need help ? we have a [discord](https://discord.gg/knequ9t) server for support**

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from .controlled import ControlledPlugin
+from .controlled import ControlLEDPlugin

--- a/controlled.py
+++ b/controlled.py
@@ -1,8 +1,49 @@
-from jasper import plugin
 import serial
-import logger
+from naomi import plugin
 
-class ControlledPlugin(plugin.SpeechHandlerPlugin):
+class ControlLEDPlugin(plugin.SpeechHandlerPlugin):
+    LED = [0, 0]
+    GREEN = 0
+    RED = 1
+    ON = 1
+    OFF = 0
+    _SER = None
+
+    # I seem to have to open the serial port in the init method
+    # because it never seems to work right directly after opening.
+    # If I give it a second, it seems to work better.
+    def __init__(self, *args, **kwargs):
+        super(ControlLEDPlugin, self).__init__(*args, **kwargs)
+        try:
+            # Buster seems to see an arduino as an ACM device, not
+            # a USB device.
+            # There are a lot of things that can go wrong here, including
+            # having something else (like a 3D printer or something)
+            # already using the ttyACM0 device, in which case it might be
+            # ttyACM1
+            # This should probably be a property that the user can set in
+            # the profile.yml
+            self._SER = serial.Serial(
+                port='/dev/ttyACM0',
+                baudrate=9600,
+                timeout=0
+            )
+        except serial.serialutil.SerialException as e:
+            warning_msg = e.args[1]
+            try:
+                self._SER = serial.Serial(
+                    port='/dev/ttyUSB0',
+                    baudrate=9600,
+                    timeout=0
+                )
+                print("Reading: {}".format(self._SER.read_until()))
+            except Exception as e:
+                warning_msg = e.args[1]
+        if not self._SER:
+            raise serial.serialutil.SerialException(warning_msg)
+
+    # AJC 2019 - I am leaving these phrases as is for the moment, so
+    # this plugin will be compatible with both Naomi 2.2 and Naomi 3.0+
     def get_phrases(self):
         """
         Keyword list to trigger this module
@@ -12,31 +53,106 @@ class ControlledPlugin(plugin.SpeechHandlerPlugin):
             self.gettext("RED"),
             self.gettext("GREEN"),
             self.gettext("ON"),
-            self.gettext("OFF"),
-            self.gettext('TEMPERATURE')]
+            self.gettext("OFF")
+        ]
+    
+    def intents(self):
+        _ = self.gettext
+        return {
+            'LEDIntent': {
+                'keywords': {
+                    'LEDThingKeyword': [
+                        _('ELLEEDEE'),
+                        _('LIGHT')
+                    ],
+                    'LEDColorKeyword': [
+                        _('RED'),
+                        _('GREEN')
+                    ],
+                    'LEDOperationKeyword': [
+                        _('ON'),
+                        _('OFF')
+                    ]
+                },
+                'templates': [
+                    _("TURN THE {LEDColorKeyword} {LEDThingKeyword} {LEDOperationKeyword}"),
+                    _("TURN {LEDOperationKeyword} THE {LEDColorKeyword} {LEDThingKeyword}")
+                ],
+                'action': self.handle
+            }
+        }
 
-    def handle(self, text, mic):
+    def switch(self, COLOR, ACTION):
+        # Set a default warning message in case something
+        # goes wrong but we are unable to extract an error message
+        warning_msg = "An unknown error has occurred"
+        # if the serial connection goes out of scope, then the arduino
+        # seems to reset
+        if self._SER:
+            cmd = bytes([65 + (COLOR * 2) + (1 - ACTION)])
+            self._SER.write(cmd)
+            self.LED[COLOR] = ACTION
+
+    def handle(self, intent, mic):
         """
         Once the brain detected the keywords above,
         it trigger this part
         """
-        try:
-            ser = serial.Serial('/dev/ttyUSB0', 9600)
+        COLOR = None
+        ACTION = None
+        if(isinstance(intent, dict)):
+            # Naomi 3.0+
+            text = intent['input']
+            try:
+                COLORS= intent['matches']['LEDColorKeyword']
+            except KeyError:
+                COLORS = None
+            try:
+                ACTION = intent['matches']['LEDOperationKeyword'][0]
+            except KeyError:
+                ACTION = None
         else:
-            break
-
-        if self.gettext('GREEN').upper() in text.upper():
+            # Naomi 2.2-
+            text = intent
+            COLORS = []
+            if self.gettext('GREEN').upper() in text.upper():
+                COLORS.append('GREEN')
+            if self.gettext('RED').upper() in text.upper():
+                COLORS.append('RED')
             if self.gettext('ON').upper() in text.upper():
-                ser.write('A') #set the green led on ON
+                ACTION = "ON"
+            if self.gettext('OFF').upper() in text.upper():
+                ACTION = "OFF"
+        try:
+            if COLORS:
+                for COLOR in COLORS:
+                    if COLOR == 'GREEN':
+                        if ACTION == "ON" or(ACTION == "" and self.GREEN == self.OFF):
+                            # Turn green on
+                            self.switch(self.GREEN, self.ON)
+                        else:
+                            self.switch(self.GREEN, self.OFF)
+                    elif COLOR == 'RED':
+                        if ACTION == "ON" or(ACTION == "" and self.RED == self.OFF):
+                            # Turn red on
+                            self.switch(self.RED, self.ON)
+                        else:
+                            self.switch(self.RED, self.OFF)
             else:
-                ser.write('B') #set the green led on OFF
-        elif self.gettext('RED').upper() in text.upper():
-            if self.gettext('ON').upper() in text.upper():
-                ser.write('C') #set the red led on ON
-            else:
-                ser.write('D') #set the red led on OFF
+                if ACTION == "ON":
+                    self.switch(self.GREEN, self.ON)
+                    self.switch(self.RED, self.ON)
+                elif ACTION == "OFF":
+                    self.switch(self.GREEN, self.OFF)
+                    self.switch(self.RED, self.OFF)
+                else:
+                    self.switch(self.GREEN, self.LED[1 - self.GREEN])
+                    self.switch(self.RED, self.LED[1 - self.RED])
+        except serial.serialutil.SerialException as e:
+            self._logger.warn(e.args[0])
 
-
+    # Is valid is only used by Naomi 2.2 and below. For Naomi 3.0+
+    # it is ignored.
     def is_valid(self, text):
         """
         Returns True if the input is related to controlled.

--- a/locale/en-US.po
+++ b/locale/en-US.po
@@ -1,34 +1,42 @@
-# This file is distributed under the same license as the Naomi package.
-#
-#, fuzzy
+# #-#-#-#-#  en-US.po (Naomi 2.2-dev)  #-#-#-#-#
+# Naomi Control-LED translations
 msgid ""
 msgstr ""
-"Project-Id-Version: Controlled Plugin for Naomi\n"
-"Report-Msgid-Bugs-To: https://github.com/NaomiProject/Naomi/issues\n"
-"POT-Creation-Date: 2018-08-11 17:00+0100\n"
-"PO-Revision-Date: 2018-08-11 17:00+0100\n"
-"Last-Translator: Sebastien Rocca <se.rocca84@gmail.com>\n"
+"Project-Id-Version: Naomi 3.0\n"
+"POT-Creation-Date: 2019-11-02 19:31-0400\n"
+"PO-Revision-Date: 2019-11-02 19:31-0400\n"
 "Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+"X-Generator: Poedit 2.2.4\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:52
 msgid "LED"
 msgstr ""
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:53 controlled.py:120
 msgid "RED"
 msgstr ""
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:54 controlled.py:118
 msgid "GREEN"
 msgstr ""
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:55 controlled.py:122
 msgid "ON"
 msgstr ""
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:56 controlled.py:124
 msgid "OFF"
+msgstr ""
+
+#: controlled.py:78
+msgid "TURN THE {LEDColorKeyword} {LEDThingKeyword} {LEDOperationKeyword}"
+msgstr ""
+
+#: controlled.py:79
+msgid "TURN {LEDOperationKeyword} THE {LEDColorKeyword} {LEDThingKeyword}"
 msgstr ""

--- a/locale/fr-FR.po
+++ b/locale/fr-FR.po
@@ -1,34 +1,51 @@
-# This file is distributed under the same license as the Naomi package.
-#
-#, fuzzy
+# #-#-#-#-#  fr-FR.po (Naomi 2.2-dev)  #-#-#-#-#
+# Naomi Control-LED translations
 msgid ""
 msgstr ""
-"Project-Id-Version: Controlled Plugin for Naomi\n"
-"Report-Msgid-Bugs-To: https://github.com/NaomiProject/Naomi/issues\n"
-"POT-Creation-Date: 2018-08-11 17:00+0100\n"
-"PO-Revision-Date: 2018-08-11 17:00+0100\n"
-"Last-Translator: Sebastien Rocca <se.rocca84@gmail.com>\n"
-"Language: fr_FR\n"
+"Project-Id-Version: Naomi 3.0\n"
+"POT-Creation-Date: 2019-11-02 19:35-0400\n"
+"PO-Revision-Date: 2019-11-02 22:47-0400\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+"X-Generator: Poedit 2.2.4\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fr_FR\n"
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:52
 msgid "LED"
-msgstr "LED"
+msgstr "DEL"
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:53 controlled.py:69 controlled.py:120
 msgid "RED"
 msgstr "ROUGE"
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:54 controlled.py:70 controlled.py:118
 msgid "GREEN"
 msgstr "VERTE"
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:55 controlled.py:73 controlled.py:122
 msgid "ON"
 msgstr "ALLUME"
 
-#: plugins/speechhandler/controlled/Controlled.py:113
+#: controlled.py:56 controlled.py:74 controlled.py:124
 msgid "OFF"
 msgstr "ETEINT"
+
+#: controlled.py:65
+msgid "ELLEEDEE"
+msgstr "DAYEHHEHLL"
+
+#: controlled.py:66
+msgid "LIGHT"
+msgstr "LUMIÈRE"
+
+#: controlled.py:78
+msgid "TURN THE {LEDColorKeyword} {LEDThingKeyword} {LEDOperationKeyword}"
+msgstr "{LEDOperationKeyword} LA {LEDThingKeyword} {LEDColorKeyword}"
+
+#: controlled.py:79
+#, fuzzy
+msgid "TURN {LEDOperationKeyword} THE {LEDColorKeyword} {LEDThingKeyword}"
+msgstr "{LEDOperationKeyword} LA {LEDThingKeyword} {LEDColorKeyword}"

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -1,0 +1,1 @@
+pyserial


### PR DESCRIPTION
This updates the Control-LED plugin to work with Python3 by requiring the "serial" module instead of the "Serial" module. It leaves the old "is_valid" and "get_phrases" methods in place but also adds the new "intents" method, so it would be compatible with any version of Naomi as long as it uses python 3.

I was finding that when I tried using this as-is, the arduino seemed to have trouble responding to the first command. I think this is from sending the command so quickly after initializing the channel. When performing the actions manually, everything seemed to work fine. I moved the serial port initialization into the __init__ method and made the connection a property of the plugin, which seemed to help.

I also added a bit of memory so that "red led" would reverse whatever the current status of the red led is, and added "ELLEEDEE" (en) and "DAYEHHEHLL" (fr) to try and capture the pronunciation without modifying the standard dictionary, although that would probably be preferable. I'm not sure if it is common in French to use the initials or diode électroluminescente or what.

I also added a python-requirements.txt file so it should automatically install the pyserial library when someone installs it using the Naomi store.

I also updated the diagram to use a 100 ohm resister for the 3V green LED and 150 for the 2V red LED, plus repositioned the leads so the longer one is towards positive.